### PR TITLE
Fix Kraken amend overwriting order ID

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -2132,7 +2132,9 @@ export default class kraken extends Exchange {
           throw new ExchangeError ('Amend error ' + error.toString ());
         }
         const result = this.safeDict (response, 'result', {});
-        return this.parseOrder (result, market);
+        // parseOrder treats amend_id as an order ID, which makes CCXT respond to editOrder with a brand new order ID.
+        // This is a bad idea because the caller will think that the exchange order ID has changed.
+        return this.safeOrder ({ 'id': id }, market);
     }
 
     /**


### PR DESCRIPTION
The CCXT implementation of amend order is bad on Kraken. Kraken responds to the amend with an amend_id. CCXT now processes this amend_id as an Order ID and responds with a msg that makes the caller think that the Exchange Order ID changed. We should just respond with the old exchange order ID instead.