### PR TITLE
TL-246 [Ndax] Fix subscription objects

### DIFF
--- a/ts/src/pro/ndax.ts
+++ b/ts/src/pro/ndax.ts
@@ -581,7 +581,13 @@ export default class ndax extends ndaxRest {
                 'n': name, // function name is the name of the function being called or that the server is responding to, the server echoes your call
                 'o': this.json (payload), // JSON-formatted string containing the data being sent with the message
             };
-            this.watch (url, messageHash, request, messageHash, future);
+            const subscription: Dict = {
+                'id': requestId,
+                'messageHash': messageHash,
+                'name': name,
+                'params': params,
+            };
+            this.watch (url, messageHash, request, messageHash, subscription);
         }
         return await future;
     }
@@ -645,8 +651,14 @@ export default class ndax extends ndaxRest {
             'n': name, // function name is the name of the function being called or that the server is responding to, the server echoes your call
             'o': this.json (payload), // JSON-formatted string containing the data being sent with the message
         };
+        const subscription: Dict = {
+            'id': requestId,
+            'messageHash': messageHash,
+            'name': name,
+            'params': params,
+        };
         const message = this.extend (request, params);
-        return await this.watch (url, messageHash, message, name);
+        return await this.watch (url, messageHash, message, name, subscription);
     }
 
     handleSubscribeAccountEvents (client: Client, message) {


### PR DESCRIPTION
The Ndax CCXT Pro handleSubscriptionStatus function searches through `client.subscriptions` to find the id of the subscription that was requested. The `watchOrderBook` subscription populated this dict with subscription objects containing the id. The `authenticate` and `watchAccountEvents` populated it with a future or just `True`. The `handleSubscriptionStatus` function crashes when it calls the `indexBy` function on `client.subscriptions` because `indexBy` doesn't know how to get the `id` from a future or a boolean. Update `authenticate` and `watchAccountEvents` to populate with a structure similar to `watchOrderBook` even though those functions don't really need the structure.