### PR TITLE
TL-282 [Ndax] Fetch order by ClientOrderID

### DIFF
--- a/ts/src/ndax.ts
+++ b/ts/src/ndax.ts
@@ -1941,9 +1941,7 @@ export default class ndax extends Exchange {
         await this.loadAccounts ();
         const defaultAccountId = this.safeInteger2 (this.options, 'accountId', 'AccountId', parseInt (this.accounts[0]['id']));
         const accountId = this.safeInteger2 (params, 'accountId', 'AccountId', defaultAccountId);
-        const clientOrderId = this.safeInteger2 (params, 'ClientOrderId', 'clientOrderId');
-        params = this.omit (params, [ 'accountId', 'AccountId', 'clientOrderId', 'ClientOrderId' ]);
-        // params = this.omit (params, [ 'accountId', 'AccountId' ]);
+        params = this.omit (params, [ 'accountId', 'AccountId' ]);
         let market = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
@@ -1951,11 +1949,8 @@ export default class ndax extends Exchange {
         const request: Dict = {
             'omsId': omsId,
             'AccountId': accountId,
-            // 'OrderId': parseInt (id),
+            'OrderId': parseInt (id),
         };
-        if (clientOrderId !== undefined) {
-            request['ClientOrderId'] = clientOrderId;
-        }
         const response = await this.privateGetGetOrderStatus (this.extend (request, params));
         //
         //     {

--- a/ts/src/ndax.ts
+++ b/ts/src/ndax.ts
@@ -1842,7 +1842,8 @@ export default class ndax extends Exchange {
         await this.loadAccounts ();
         const defaultAccountId = this.safeInteger2 (this.options, 'accountId', 'AccountId', parseInt (this.accounts[0]['id']));
         const accountId = this.safeInteger2 (params, 'accountId', 'AccountId', defaultAccountId);
-        params = this.omit (params, [ 'accountId', 'AccountId' ]);
+        const clientOrderId = this.safeInteger2 (params, 'ClientOrderId', 'clientOrderId');
+        params = this.omit (params, [ 'accountId', 'AccountId', 'clientOrderId', 'ClientOrderId' ]);
         const request: Dict = {
             'omsId': omsId,
             'AccountId': accountId,
@@ -1866,6 +1867,9 @@ export default class ndax extends Exchange {
         }
         if (limit !== undefined) {
             request['Depth'] = limit;
+        }
+        if (clientOrderId !== undefined) {
+            request['ClientOrderId'] = clientOrderId;
         }
         const response = await this.privateGetGetOrdersHistory (this.extend (request, params));
         //
@@ -1937,7 +1941,9 @@ export default class ndax extends Exchange {
         await this.loadAccounts ();
         const defaultAccountId = this.safeInteger2 (this.options, 'accountId', 'AccountId', parseInt (this.accounts[0]['id']));
         const accountId = this.safeInteger2 (params, 'accountId', 'AccountId', defaultAccountId);
-        params = this.omit (params, [ 'accountId', 'AccountId' ]);
+        const clientOrderId = this.safeInteger2 (params, 'ClientOrderId', 'clientOrderId');
+        params = this.omit (params, [ 'accountId', 'AccountId', 'clientOrderId', 'ClientOrderId' ]);
+        // params = this.omit (params, [ 'accountId', 'AccountId' ]);
         let market = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
@@ -1945,8 +1951,11 @@ export default class ndax extends Exchange {
         const request: Dict = {
             'omsId': omsId,
             'AccountId': accountId,
-            'OrderId': parseInt (id),
+            // 'OrderId': parseInt (id),
         };
+        if (clientOrderId !== undefined) {
+            request['ClientOrderId'] = clientOrderId;
+        }
         const response = await this.privateGetGetOrderStatus (this.extend (request, params));
         //
         //     {


### PR DESCRIPTION
The GetOrdersHistory endpoint allows searching by ClientOrderID. If we set the `limit` to 1, it should only return the most recent entry.