### PR TITLE
TL-285 Workaround Binance USA IP block

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -224,7 +224,7 @@ export default class binance extends Exchange {
                     'fapiPrivateV2': 'https://fapi.binance.com/fapi/v2',
                     'fapiPrivateV3': 'https://fapi.binance.com/fapi/v3',
                     'fapiData': 'https://fapi.binance.com/futures/data',
-                    'public': 'https://api.binance.com/api/v3',
+                    'public': 'https://data-api.binance.vision/api/v3',
                     'private': 'https://api.binance.com/api/v3',
                     'v1': 'https://api.binance.com/api/v1',
                     'papi': 'https://papi.binance.com/papi/v1',
@@ -1268,8 +1268,8 @@ export default class binance extends Exchange {
                 'fetchMargins': true,
                 'fetchMarkets': [
                     'spot', // allows CORS in browsers
-                    'linear', // allows CORS in browsers
-                    'inverse', // allows CORS in browsers
+                    // 'linear', // allows CORS in browsers
+                    // 'inverse', // allows CORS in browsers
                     // 'option', // does not allow CORS, enable outside of the browser only
                 ],
                 'fetchCurrencies': true, // this is a private call and it requires API keys

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -82,8 +82,8 @@ export default class binance extends binanceRest {
                 },
                 'api': {
                     'ws': {
-                        'spot': 'wss://stream.binance.com:9443/ws',
-                        'margin': 'wss://stream.binance.com:9443/ws',
+                        'spot': 'wss://data-stream.binance.vision:9443/ws',
+                        'margin': 'wss://data-stream.binance.vision:9443/ws',
                         'future': 'wss://fstream.binance.com/ws',
                         'delivery': 'wss://dstream.binance.com/ws',
                         'ws-api': {


### PR DESCRIPTION
Binance blocks USA IPs from its API. However, it seems that the data-only API server does not block USA IPs. Change things around such that we use the data-only API for public endpoints. Also reconfigure to only do spot and not linear or inverse on Binance because I can't find any data-only API addresses for those.