### PR TITLE
TL-293 ClientOrderID support when placing crypto.com orders

### DIFF
--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -1207,6 +1207,10 @@ export default class cryptocom extends Exchange {
             request['exec_inst'] = [ 'POST_ONLY' ];
             request['time_in_force'] = 'GOOD_TILL_CANCEL';
         }
+        const clientOrderId = this.safeString2 (params, 'clientOrderId', 'ClientOrderId');
+        if (clientOrderId !== undefined) {
+            request['client_oid'] = clientOrderId;
+        }
         const triggerPrice = this.safeStringN (params, [ 'stopPrice', 'triggerPrice', 'ref_price' ]);
         const stopLossPrice = this.safeNumber (params, 'stopLossPrice');
         const takeProfitPrice = this.safeNumber (params, 'takeProfitPrice');
@@ -1416,6 +1420,10 @@ export default class cryptocom extends Exchange {
         if ((postOnly) || (timeInForce === 'PO')) {
             request['exec_inst'] = [ 'POST_ONLY' ];
             request['time_in_force'] = 'GOOD_TILL_CANCEL';
+        }
+        const clientOrderId = this.safeString2 (params, 'clientOrderId', 'ClientOrderId');
+        if (clientOrderId !== undefined) {
+            request['client_oid'] = clientOrderId;
         }
         const triggerPrice = this.safeStringN (params, [ 'stopPrice', 'triggerPrice', 'ref_price' ]);
         const stopLossPrice = this.safeNumber (params, 'stopLossPrice');


### PR DESCRIPTION
Would like to update cancel_order and fetch_order too, but will save that for when we have OMS do the cancel/replace.