### PR TITLE
TL-510 Fix fetchFundingHistory for Hyperliquid HIP3

### DIFF
--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -4604,16 +4604,18 @@ export default class hyperliquid extends Exchange {
         const id = this.safeString (income, 'hash');
         const timestamp = this.safeInteger (income, 'time');
         const delta = this.safeDict (income, 'delta');
-        const baseId = this.safeString (delta, 'coin');
-        const marketSymbol = baseId + '/USDC:USDC';
-        market = this.safeMarket (marketSymbol);
-        const symbol = market['symbol'];
+        const coin = this.safeString (delta, 'coin');
+        let marketId = undefined;
+        if (coin !== undefined) {
+            marketId = this.coinToMarketId(coin);
+        }
+        market = this.safeMarket (marketId, market);
         const amount = this.safeString (delta, 'usdc');
-        const code = this.safeCurrencyCode ('USDC');
+        const code = this.safeString (market, 'settle', 'USDC');
         const rate = this.safeNumber (delta, 'fundingRate');
         return {
             'info': income,
-            'symbol': symbol,
+            'symbol': market['symbol'],
             'code': code,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),


### PR DESCRIPTION
- Hyperliquid parseIncome function doesn't parse HIP3 markets properly. This fixes it.